### PR TITLE
fix broken GSOD blog links

### DIFF
--- a/_pages/contribute.adoc
+++ b/_pages/contribute.adoc
@@ -33,4 +33,4 @@ please apply at the https://github.com/rnpgp/rnp/discussions[Discussions page]
 or directly contact open.source@ribose.com.
 
 The Metanorma GSoD 2021 proposal is available
-link:/blog/2021-03-26/rnp-gsod-2021[here].
+link:/blog/2021-03-26-rnp-gsod-2021[here].

--- a/custom-intro.html
+++ b/custom-intro.html
@@ -2,7 +2,7 @@
   <p>
     Technical writer?
     Please take a look at <a href="https://github.com/rnpgp/rnp/tree/master/docs">RNP docs on GitHub</a>
-    and read our <a href="/blog/2021-03-26/rnp-gsod-2021/">Google Season of Docs proposal blog post</a>,
+    and read our <a href="/blog/2021-03-26-rnp-gsod-2021/">Google Season of Docs proposal blog post</a>,
     contributions are appreciated!
   </p>
 </section>


### PR DESCRIPTION
Fix 404 blog link on main homepage and contributing pages